### PR TITLE
Claude code fixes nondeterministic intra-doc links for methods

### DIFF
--- a/src/intralinks.rs
+++ b/src/intralinks.rs
@@ -508,7 +508,21 @@ struct ItemPath<'a> {
 fn collect_all_items_info(krate: &Crate) -> HashMap<Id, ItemInfo<'_>> {
     let mut items_info: HashMap<Id, ItemInfo<'_>> = HashMap::with_capacity(krate.index.len());
 
-    for (&item_id, item_summary) in &krate.paths {
+    // `krate.paths` has an entry for every path-addressable item, including
+    // methods (their `ItemSummary::kind` is indistinguishable from a
+    // free function). Process non-function entries first, so that structs,
+    // enums, traits, etc. get fully traversed - via `transitive_items` -
+    // before we look at any path entry that is a `Function`. That way, a
+    // path entry that is actually a method has already been recorded with
+    // the correct `ItemKind::Method`/`ItemKind::TyMethod` (learned from
+    // its real impl/trait parent) by the time we'd otherwise insert it
+    // as a context-free, and wrongly kinded, top-level function.
+    let (function_paths, other_paths): (Vec<_>, Vec<_>) = krate
+        .paths
+        .iter()
+        .partition(|(_, item_summary)| item_summary.kind == rustdoc_types::ItemKind::Function);
+
+    for (&item_id, item_summary) in other_paths.into_iter().chain(function_paths) {
         let item_info = ItemInfo::new(item_summary, None, None);
 
         transitive_items(item_id, &item_info, None, krate, &mut items_info);


### PR DESCRIPTION
> **NOTE**: The contents of this PR was drafted with AI assistance.

Hi. Updating dependencies (PR #7) seems to help a lot with #8, but doesn't really fix the problem.

I asked Claude Code (Sonnet) to fix the problem, and this PR is what it produced.

It appears to fix the bug, but I realize you may not want to accept code generated by an LLM.

Here is how Claude describes the problem:
> Summary
>
> - krate.paths (from rustdoc JSON) contains a path entry for every path-addressable item, including methods — and a method's ItemSummary::kind is Function, indistinguishable from a free function at that point.
> - collect_all_items_info iterated krate.paths in HashMap order and built an ItemInfo for every entry directly. A method's own context-free entry could race against the correct entry discovered by traversing its struct/impl parent (which knows it's really a Method/TyMethod) — whichever was visited first won, and HashMap iteration order is randomized per process.
> - Net effect: intra-doc links like [free](IdAllocator::free) resolved correctly (struct.IdAllocator.html#method.free) or incorrectly (struct.IdAllocator.htmlfn.free.html) depending on the run — the same input crate could produce different output on different invocations.
> - Fix: process non-Function path entries first (structs, enums, traits, ...), so their traversal always records methods with the correct ItemKind before any bare Function path entry is considered. A genuine free function is unaffected since nothing else claims its Id first.
>
> Test plan
>
> - [x] Reproduced the bug on a minimal crate (struct with one inherent method, doc comment linking to it via Type::method) — flaky ~1/3 of runs before the fix.
> - [x] Same repro run 20x after the fix: consistently correct (#method.free) every time.
> - [x] cargo test --lib intralinks passes.
> - [ ] Reviewer: consider running the existing top_crates integration test suite if it covers intra-doc links across a wider crate sample.